### PR TITLE
Map macOS return codes from alert:runModal to atari button codes

### DIFF
--- a/MIDIMaze/Helper Sources/AtariTOS.mm
+++ b/MIDIMaze/Helper Sources/AtariTOS.mm
@@ -632,6 +632,22 @@ short form_alert(short defbut,const char *astring)
             [alert addButtonWithTitle:buttonStr];
         }
         ret = [alert runModal];
+        switch (ret) {
+        case NSModalResponseOK:
+        case NSAlertFirstButtonReturn:
+            ret = 1;
+            break;
+        case NSModalResponseCancel:
+        case NSAlertSecondButtonReturn:
+            ret = 2;
+            break;
+        case NSAlertThirdButtonReturn:
+            ret = 3;
+            break;
+        default:
+            ret = 0;
+            break;
+        }
     });
     gAltKeyCode = 0;
     return (int)ret;


### PR DESCRIPTION
macOS returns codes like 1000, but form_alert() expects value in range 1-3. This currently only affects the alert which asks for game termination when pressing ESC.

PS.: when merging PRs, i would suggest to use "Rebase and Merge". That avoids creating a second commit for the merge, resulting in a cleaner git history.
